### PR TITLE
Add zero-iching CLI scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# zero-iching
+
+A template command line interface package.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+zero-iching --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zero-iching"
+version = "0.1.0"
+description = "Template CLI for zero-iching"
+authors = [{name = "Example", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+zero-iching = "zero_iching.cli:main"

--- a/zero_iching/CLI_HELP.md
+++ b/zero_iching/CLI_HELP.md
@@ -1,0 +1,11 @@
+# zero-iching Help
+
+## Description
+Template command line interface for zero-iching.
+
+## Usage
+`zero-iching [OPTIONS]`
+
+## Options
+- `-h`, `--help` Show this help message and exit.
+- `--version` Display the version.

--- a/zero_iching/__init__.py
+++ b/zero_iching/__init__.py
@@ -1,0 +1,8 @@
+"""Main library module for zero-iching CLI."""
+
+
+def main():
+    """Entry point for zero-iching library."""
+    print("zero-iching main library called")
+    return 0
+

--- a/zero_iching/cli.py
+++ b/zero_iching/cli.py
@@ -1,0 +1,40 @@
+"""Command line interface for zero-iching."""
+import argparse
+import os
+from zero_iching import main as zero_iching_alias
+
+
+def load_help_text() -> str:
+    """Load help text from CLI_HELP.md."""
+    help_path = os.path.join(os.path.dirname(__file__), "CLI_HELP.md")
+    try:
+        with open(help_path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return "Help documentation not found."
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    help_text = load_help_text()
+    parser = argparse.ArgumentParser(
+        prog="zero-iching",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="zero-iching command line interface",
+        epilog=help_text,
+    )
+    parser.add_argument("--version", action="version", version="zero-iching 0.1.0")
+    return parser
+
+
+def main(argv=None) -> int:
+    """Entry point for the command line."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # Execute the library main function
+    return zero_iching_alias()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- scaffold minimal `zero-iching` CLI package
- include CLI entrypoint and library `main`
- provide help text in `CLI_HELP.md`
- configure packaging via `pyproject.toml`

## Testing
- `python3 -m zero_iching.cli --help`
- `python3 -m pip install -e .` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842103f8b748323908f8dd0d6b94027