### PR TITLE
Add hexagram printing helper

### DIFF
--- a/zero_iching/helpers.py
+++ b/zero_iching/helpers.py
@@ -5,3 +5,34 @@ def uuid_to_bin(uuid_str):
     hex_str = uuid_str.replace('-', '')
     return bin(int(hex_str, 16))[2:].zfill(128)
 
+
+YANG_LINE = "---"
+YIN_LINE = "- -"
+
+
+def print_hexagram(hexagram_lines, scale=1):
+    """Print a hexagram using text characters.
+
+    Parameters
+    ----------
+    hexagram_lines : list[str]
+        Sequence of six line descriptors from bottom to top. Each
+        descriptor should match ``YANG_LINE`` or ``YIN_LINE``.
+    scale : int, optional
+        Size multiplier controlling the width and height of each line.
+        ``scale`` must be a positive integer.
+    """
+
+    if len(hexagram_lines) != 6:
+        raise ValueError("hexagram_lines must contain exactly 6 elements")
+    if scale < 1:
+        raise ValueError("scale must be >= 1")
+
+    yang_segment = "━" * (3 * scale)
+    yin_segment = "━" * scale + " " * scale + "━" * scale
+
+    for line in reversed(hexagram_lines):
+        segment = yang_segment if line.strip() == YANG_LINE else yin_segment
+        for _ in range(scale):
+            print(segment)
+


### PR DESCRIPTION
## Summary
- expand helper utilities with `print_hexagram`
- define Yin/Yang line constants

## Testing
- `python -m compileall -q zero_iching`

------
https://chatgpt.com/codex/tasks/task_e_684216aa9ce483238b2c02e4f18437e1