### PR TITLE
Implement uuid-based divination command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ pip install -e .
 ```bash
 zero-iching --help
 ```
+
+### Example
+
+Derive three hexagrams from a UUID via the CLI:
+
+```bash
+zero-iching uuid --uuid 'd682da34-d320-4e72-824b-a42b0c801270' -n 3
+```
+
+If `--uuid` is provided with an empty string, a random UUID4 will be used.

--- a/zero_iching/CLI_HELP.md
+++ b/zero_iching/CLI_HELP.md
@@ -4,8 +4,18 @@
 Template command line interface for zero-iching.
 
 ## Usage
-`zero-iching [OPTIONS]`
+`zero-iching [OPTIONS] COMMAND [ARGS]...`
 
 ## Options
 - `-h`, `--help` Show this help message and exit.
 - `--version` Display the version.
+
+## Commands
+- `uuid` Derive hexagrams from a UUID.
+
+### `uuid` command
+`zero-iching uuid --uuid <UUID> -n <NUM>`
+
+- `--uuid` UUID to divine from. If an empty string is provided, a random
+  UUID4 is generated.
+- `-n` Number of hexagrams to produce (default: `1`).

--- a/zero_iching/cli.py
+++ b/zero_iching/cli.py
@@ -1,7 +1,11 @@
 """Command line interface for zero-iching."""
 import argparse
 import os
+from uuid import uuid4 as uuid
+
 from zero_iching import main as zero_iching_alias
+from zero_iching.helpers import print_hexagram
+from zero_iching.uuid_diviner import hexagrams_from_uuid
 
 
 def load_help_text() -> str:
@@ -24,6 +28,24 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=help_text,
     )
     parser.add_argument("--version", action="version", version="zero-iching 0.1.0")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    uuid_parser = subparsers.add_parser(
+        "uuid", help="Derive hexagrams from a UUID"
+    )
+    uuid_parser.add_argument(
+        "--uuid",
+        default=None,
+        help="UUID to divine from. Provide empty string to generate a random one.",
+    )
+    uuid_parser.add_argument(
+        "-n",
+        type=int,
+        default=1,
+        help="Number of hexagrams to produce",
+    )
+
     return parser
 
 
@@ -32,7 +54,18 @@ def main(argv=None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # Execute the library main function
+    if args.command == "uuid":
+        uuid_str = args.uuid
+        if uuid_str is None or uuid_str == "":
+            uuid_str = str(uuid())
+        hexagrams = hexagrams_from_uuid(uuid_str, n=args.n)
+        print(f"UUID: {uuid_str}")
+        for hexagram in hexagrams:
+            print_hexagram(hexagram)
+            print()
+        return 0
+
+    # Default behavior
     return zero_iching_alias()
 
 


### PR DESCRIPTION
## Summary
- add new `uuid` subcommand to CLI
- document the new usage in `CLI_HELP.md` and `README.md`

## Testing
- `python -m zero_iching.cli --help | head -n 20`
- `python -m zero_iching.cli uuid --uuid 'd682da34-d320-4e72-824b-a42b0c801270' -n 1`
- `python -m zero_iching.cli uuid --uuid '' -n 2`
- `python -m zero_iching.cli uuid -n 1`
- `pip install -e .` *(fails: could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842195d24a8832394699fc10086879b