### PR TITLE
Add templated hexagram output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,7 @@ Derive three hexagrams from a UUID via the CLI:
 zero-iching uuid --uuid 'd682da34-d320-4e72-824b-a42b0c801270' -n 3
 ```
 
+The output is now formatted using a Jinja2 template and includes trigram names
+and symbols.
+
 If `--uuid` is provided with an empty string, a random UUID4 will be used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ description = "Template CLI for zero-iching"
 authors = [{name = "Example", email = "example@example.com"}]
 readme = "README.md"
 requires-python = ">=3.8"
+dependencies = ["jinja2>=3.0"]
 
 [project.scripts]
 zero-iching = "zero_iching.cli:main"
+
+[tool.setuptools.package-data]
+"zero_iching.templates" = ["*.jinja2"]

--- a/zero_iching/templates/uuid_output.jinja2
+++ b/zero_iching/templates/uuid_output.jinja2
@@ -1,0 +1,7 @@
+UUID: {{ uuid }}
+
+{% for hx in hexagrams %}
+Hexagram {{ loop.index }}: {{ hx.upper_symbol }} above {{ hx.lower_symbol }}
+  Names: {{ hx.upper_name }} ({{ hx.upper_en }}) over {{ hx.lower_name }} ({{ hx.lower_en }})
+  Binary: {{ hx.code }} ({{ hx.upper_code }} | {{ hx.lower_code }})
+{% endfor %}


### PR DESCRIPTION
## Summary
- format `uuid` command results with Jinja2 template
- include trigram names and symbols in CLI output
- package template files
- document the new behaviour

## Testing
- `python -m zero_iching.cli uuid --uuid '' -n 2` *(fails: ModuleNotFoundError: No module named 'jinja2')*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement jinja2)*

------
https://chatgpt.com/codex/tasks/task_e_684228b12e2c83238a8385cfd70825e7