### PR TITLE
Extend trigram output

### DIFF
--- a/zero_iching/cli.py
+++ b/zero_iching/cli.py
@@ -6,7 +6,12 @@ from uuid import uuid4 as uuid
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from zero_iching import main as zero_iching_alias
-from zero_iching.helpers import HEXAGRAM_NAMES, HEXAGRAM_EN_NAMES, HEXAGRAM_SYMBOLS
+from zero_iching.helpers import (
+    HEX_DESC,
+    HEXAGRAM_NAMES,
+    HEXAGRAM_EN_NAMES,
+    HEXAGRAM_SYMBOLS,
+)
 from zero_iching.uuid_diviner import hexagrams_from_uuid
 
 
@@ -69,6 +74,8 @@ def render_uuid_hexagrams(uuid_str: str, n: int = 1) -> str:
                 "upper_en": HEXAGRAM_EN_NAMES.get(upper, ""),
                 "lower_symbol": HEXAGRAM_SYMBOLS.get(lower, ""),
                 "upper_symbol": HEXAGRAM_SYMBOLS.get(upper, ""),
+                "lower_desc": HEX_DESC.get(lower, ""),
+                "upper_desc": HEX_DESC.get(upper, ""),
             }
         )
 

--- a/zero_iching/templates/uuid_output.jinja2
+++ b/zero_iching/templates/uuid_output.jinja2
@@ -5,5 +5,7 @@ UUID: {{ uuid }}
 Hexagram {{ loop.index }}: {{ hx.upper_symbol }} above {{ hx.lower_symbol }}
   Names: {{ hx.upper_name }} ({{ hx.upper_en }}) over {{ hx.lower_name }} ({{ hx.lower_en }})
   Binary: {{ hx.code }} ({{ hx.upper_code }} | {{ hx.lower_code }})
+  {{ hx.upper_desc }}
+  {{ hx.lower_desc }}
 {% endfor %}
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include trigram descriptions in the CLI output
- show descriptions via Jinja2 template

## Testing
- `python -m compileall -q zero_iching`
- `python -m zero_iching.cli uuid --uuid '' -n 2` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_684232da3a1c832381b925c001bedf56