### PR TITLE
Implement waterfall hexagram derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 A template command line interface package.
 
-### 🔢 `hexagrams_from_uuid`: Deriving I Ching Hexagrams from UUIDs
+### 🔢 `hexagrams_from_bits`: Waterfall Reduction
 
-The `hexagrams_from_uuid` function deterministically converts a UUID string into one or more I Ching hexagrams. It interprets the UUID as a 128-bit binary stream and slices this stream into 6-bit chunks.
-
-Each chunk is returned as two three-bit codes representing the lower and upper trigrams. Bits are ordered from **bottom to top** so that `"111"` corresponds to three solid yang lines. The trigram codes can be mapped to their traditional names via `HEXAGRAM_NAMES`.
-
-Because UUIDs are 128-bit values, up to 21 hexagrams can be derived in a single call (`21 * 6 = 126 bits used`), with 2 bits remaining unused. This creates a structured, non-arbitrary way of interpreting UUIDs as symbols—ideal for symbolic systems, playful divination, or creative applications that blend data with ancient Chinese metaphysics.
+`hexagrams_from_bits` accepts any binary string and collapses it into hexagrams using a **waterfall** folding process. Starting from the full width of the input, each subsequent row is produced by XOR-ing adjacent bits. The rows shrink by one bit per step, forming a cascade until only `6 × n` bits remain. Those final bits encode the requested hexagrams. The CLI helper `hexagrams_from_uuid` simply converts a UUID to binary and delegates to this function.
 
 
 ## Installation
@@ -45,4 +41,11 @@ hexagram alongside an ASCII rendering:
 from zero_iching.uuid_demo import visualize_uuid
 
 visualize_uuid("d682da34-d320-4e72-824b-a42b0c801270", n=2)
+```
+
+The repository also includes a small `demo.py` that visualizes the waterfall
+reduction for any integer:
+
+```bash
+python demo.py 123456 2
 ```

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,21 @@
+"""Demo script showcasing waterfall reduction for an integer."""
+
+import sys
+
+from zero_iching.bit_waterfall import visualize_waterfall
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python demo.py <integer> [n_hexes]")
+        return
+    num = int(sys.argv[1])
+    n = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+    bits = bin(num)[2:]
+    print(f"Number: {num}")
+    print(f"Bits  : {bits}\n")
+    visualize_waterfall(bits, n=n)
+
+
+if __name__ == "__main__":
+    main()

--- a/zero_iching/bit_waterfall.py
+++ b/zero_iching/bit_waterfall.py
@@ -1,0 +1,76 @@
+"""Utilities for deriving hexagrams from binary strings using a
+waterfall reduction algorithm."""
+
+from typing import Callable, List, Tuple
+
+YANG_LINE = "1"
+YIN_LINE = "0"
+
+
+def _validate_bits(bits: str) -> None:
+    if not bits or set(bits) - {"0", "1"}:
+        raise ValueError("bits must be a non-empty binary string")
+
+
+def waterfall_reduce(bits: str, final_len: int, op: Callable[[int, int], int] = lambda a, b: a ^ b) -> Tuple[str, List[List[int]]]:
+    """Reduce ``bits`` to ``final_len`` using a triangular folding process.
+
+    Parameters
+    ----------
+    bits : str
+        Input binary string.
+    final_len : int
+        Desired output length in bits.
+    op : Callable[[int, int], int], optional
+        Binary operation used when folding. Defaults to XOR.
+
+    Returns
+    -------
+    Tuple[str, List[List[int]]]
+        Final bit string and history of rows used in the reduction.
+    """
+    _validate_bits(bits)
+    row = [int(b) for b in bits]
+    if final_len < 1 or final_len > len(row):
+        raise ValueError("final_len must be between 1 and the length of bits")
+    history = [row.copy()]
+    while len(row) > final_len:
+        row = [op(row[i], row[i + 1]) for i in range(len(row) - 1)]
+        history.append(row.copy())
+    return "".join(str(b) for b in row), history
+
+
+def hexagrams_from_bits(bits: str, n: int = 1) -> List[str]:
+    """Return ``n`` hexagrams derived from ``bits``.
+
+    The bits are reduced using ``waterfall_reduce`` so that the
+    final ``6 * n`` bits are used to form the hexagrams.  Each
+    hexagram is returned as a six-character string ordered from
+    bottom to top.
+    """
+    if n < 1:
+        raise ValueError("n must be >= 1")
+    needed = 6 * n
+    reduced, _ = waterfall_reduce(bits, needed)
+    hexes = []
+    for i in range(n):
+        chunk = reduced[i * 6 : (i + 1) * 6]
+        hexes.append(chunk)
+    return hexes
+
+
+def visualize_waterfall(bits: str, n: int = 1) -> None:
+    """Print the triangular waterfall reduction and resulting hexagrams."""
+    reduced, history = waterfall_reduce(bits, 6 * n)
+    width = len(history[0])
+    for depth, row in enumerate(history):
+        indent = " " * depth
+        line = "".join(str(b) for b in row)
+        print(f"{indent}{line}")
+    print()
+    print(f"final bits: {reduced}")
+    for i, hx in enumerate(hexagrams_from_bits(bits, n)):
+        lower = hx[:3]
+        upper = hx[3:]
+        print(f"Hexagram {i+1}: {upper} over {lower} -> {hx}")
+

--- a/zero_iching/cli.py
+++ b/zero_iching/cli.py
@@ -60,9 +60,9 @@ def render_uuid_hexagrams(uuid_str: str, n: int = 1) -> str:
     """Return a formatted string for ``uuid`` command output."""
     hex_list = hexagrams_from_uuid(uuid_str, n=n)
     structured = []
-    for i in range(0, len(hex_list), 2):
-        code = hex_list[i]
-        lower, upper = hex_list[i + 1]
+    for code in hex_list:
+        lower = code[:3]
+        upper = code[3:]
         structured.append(
             {
                 "code": code,

--- a/zero_iching/display_chargrid.py
+++ b/zero_iching/display_chargrid.py
@@ -1,0 +1,40 @@
+"""Render a hexagram as a decorative character grid."""
+
+from zero_iching.helpers import (
+    HEXAGRAM_NAMES,
+    HEXAGRAM_EN_NAMES,
+    print_hexagram,
+)
+
+
+def display_hex_chargrid(bits: str) -> None:
+    """Display a hexagram in a simple character grid.
+
+    Parameters
+    ----------
+    bits : str
+        Six-bit binary string ordered from bottom to top.
+    """
+    if len(bits) != 6 or set(bits) - {"0", "1"}:
+        raise ValueError("bits must be a 6-character binary string")
+
+    lower = bits[:3]
+    upper = bits[3:]
+    lower_name = HEXAGRAM_NAMES.get(lower, "")
+    upper_name = HEXAGRAM_NAMES.get(upper, "")
+    lower_en = HEXAGRAM_EN_NAMES.get(lower, "")
+    upper_en = HEXAGRAM_EN_NAMES.get(upper, "")
+    print(
+        f"Names: {upper_name} ({upper_en}) over {lower_name} ({lower_en})"
+    )
+    print(f"Binary: {bits} ({lower} | {upper})")
+    # Build a simple grid using block characters
+    for b in reversed(bits):
+        if b == "1":
+            print("⣿" * 10)
+        else:
+            print("⣿⣿⣿  ⣿⣿⣿")
+    print()
+    # Also print using the thinner print_hexagram helper
+    print_hexagram(list(bits), scale=1)
+

--- a/zero_iching/uuid_demo.py
+++ b/zero_iching/uuid_demo.py
@@ -3,6 +3,7 @@ from uuid import uuid4 as _uuid4
 
 from zero_iching import helpers
 from zero_iching.uuid_diviner import hexagrams_from_uuid, YANG_LINE, YIN_LINE
+from zero_iching.bit_waterfall import visualize_waterfall
 
 helpers.YANG_LINE = YANG_LINE
 helpers.YIN_LINE = YIN_LINE
@@ -13,48 +14,22 @@ print_hexagram = helpers.print_hexagram
 uuid_to_bin = helpers.uuid_to_bin
 
 
-def visualize_uuid(uuid_str: str, n: int = 1, offset: int = 0, scale: int = 1) -> None:
-    """Print a visual demonstration of deriving hexagrams from a UUID.
-
-    Parameters
-    ----------
-    uuid_str : str
-        UUID to interpret.
-    n : int, optional
-        Number of hexagrams to display.
-    offset : int, optional
-        Bit offset to start reading from.
-    scale : int, optional
-        Scaling factor for ``print_hexagram``.
-    """
+def visualize_uuid(uuid_str: str, n: int = 1, scale: int = 1) -> None:
+    """Print a visual demonstration of deriving hexagrams from a UUID."""
     bits = uuid_to_bin(uuid_str)
     print(f"UUID : {uuid_str}")
     print(f"Binary: {bits}\n")
-
-    # Show the 6-bit blocks that make up the hexagrams
-    blocks = [bits[i : i + 6] for i in range(0, 126, 6)]
-    tail = bits[126:]
-    for i, blk in enumerate(blocks):
-        end = "\n" if (i + 1) % 7 == 0 else "  "
-        print(f"{i:02d}:{blk}", end=end)
-    if tail:
-        print(f"tail:{tail}")
-    else:
-        print()
-
-    hex_list = hexagrams_from_uuid(uuid_str, n=n, offset=offset)
-    for i in range(0, len(hex_list), 2):
-        code = hex_list[i]
-        lower, upper = hex_list[i + 1]
-        start = offset + (i // 2) * 6
-        chunk = bits[start : start + 6]
+    visualize_waterfall(bits, n=n)
+    hex_list = hexagrams_from_uuid(uuid_str, n=n)
+    for i, code in enumerate(hex_list):
+        lower = code[:3]
+        upper = code[3:]
         lower_name = HEXAGRAM_NAMES.get(lower, "")
         upper_name = HEXAGRAM_NAMES.get(upper, "")
         lower_symbol = HEXAGRAM_SYMBOLS.get(lower, "")
         upper_symbol = HEXAGRAM_SYMBOLS.get(upper, "")
         print()
-        print(f"Hexagram {i // 2 + 1} bits [{start}:{start + 6}] -> {chunk}")
-        print(f"  {upper_symbol} over {lower_symbol} ({upper_name}/{lower_name})")
+        print(f"Hexagram {i + 1}: {upper_symbol} over {lower_symbol} ({upper_name}/{lower_name})")
         print_hexagram(list(code), scale=scale)
 
 

--- a/zero_iching/uuid_diviner.py
+++ b/zero_iching/uuid_diviner.py
@@ -1,35 +1,16 @@
 """Hexagram derivation utilities from UUIDs."""
 
 from zero_iching.helpers import uuid_to_bin
+from zero_iching.bit_waterfall import (
+    hexagrams_from_bits,
+    YANG_LINE,
+    YIN_LINE,
+)
 
-YANG_LINE = "1"
-YIN_LINE = "0"
 
+def hexagrams_from_uuid(uuid_str: str, n: int = 1) -> list[str]:
+    """Return ``n`` hexagrams derived from ``uuid_str`` using the
+    waterfall reduction algorithm."""
+    bits = uuid_to_bin(uuid_str)
+    return hexagrams_from_bits(bits, n=n)
 
-def hexagrams_from_uuid(uuid_str: str, n: int = 1, offset: int = 0):
-    """Return ``n`` hexagram codes derived from ``uuid_str``.
-
-    Each hexagram is represented as a list containing two three-character
-    binary strings. The first element corresponds to the lower trigram and
-    the second element to the upper trigram. Bits are ordered from bottom to
-    top so that ``'111'`` represents three solid (yang) lines.
-    """
-    bit_stream = uuid_to_bin(uuid_str)
-
-    if offset < 0 or n < 1:
-        raise ValueError("offset must be >= 0 and n must be >= 1")
-
-    start = offset
-    end = start + n * 6
-    if end > len(bit_stream):
-        raise ValueError("Requested range exceeds available bit length")
-
-    hexagrams = []
-    for i in range(n):
-        bits = bit_stream[start + i * 6 : start + (i + 1) * 6]
-        lines = [YANG_LINE if b == "1" else YIN_LINE for b in bits]
-        hexagrams.append(''.join(lines))
-        lower = bits[:3]
-        upper = bits[3:]
-        hexagrams.append([lower, upper])
-    return hexagrams


### PR DESCRIPTION
## Summary
- implement `bit_waterfall` module for folding binary strings into hexagrams
- update CLI and demos to use the new algorithm
- add `display_chargrid` helper for blocky hexagram output
- create `demo.py` to visualize waterfall reduction
- revise README with instructions for new features

## Testing
- `python -m compileall -q .`
- `python demo.py 123456789 2`


------
https://chatgpt.com/codex/tasks/task_e_68424622b81c832397733fa06872cf6b